### PR TITLE
Update secrets for add-to-project automation

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:
-          project-url: https://github.com/orgs/Cycling74/projects/${{ secrets.RNBO_PROJECT_NUMBER }}
-          github-token: ${{ secrets.RNBO_PROJECT_PAT }}
-          
+          project-url: https://github.com/orgs/Cycling74/projects/${{ secrets.PROJECT_NUMBER }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+          labeled: bug
+          label-operator: NOT
+


### PR DESCRIPTION
It looks like github automatically added this 'add-to-project' action. I went ahead and created a project and a simple rule that will add PR's to projects that are not labeled as bugs.

- Created String VST Project: https://github.com/users/bynarlogic/projects/1
- Created secrets for add-to-project automation